### PR TITLE
ci: add E2E test workflow and update unit test workflow

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -1,0 +1,33 @@
+name: Run E2E Tests
+
+on: [pull_request]
+
+jobs:
+  run-e2e-tests:
+    name: Run E2E Tests
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: bitnami/postgresql
+        ports:
+          - 5432:5432
+        environment:
+          - POSTGRES_USERNAME=docker
+          - POSTGRES_PASSWORD=docker
+          - POSTGRES_DATABASE=apisolid
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npm run test:e2e
+        env:
+          JWT_SECRET: testing
+          DATABASE_URL: "postgresql://docker:docker@localhost:5432/apisolid?schema=public"

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -9,6 +9,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
         with:
           node-version: 22
           cache: 'npm'


### PR DESCRIPTION
- Add `.github/workflows/run-e2e-tests.yml` to run end-to-end tests on pull requests.
- Configure PostgreSQL service for testing with environment variables.
- Set up `JWT_SECRET` and `DATABASE_URL` for the test environment.
- Use `npm run test:e2e` to execute E2E tests.